### PR TITLE
fix deprecated express method 'response.send'

### DIFF
--- a/modules/cities.js
+++ b/modules/cities.js
@@ -14,7 +14,7 @@ exports.list = function(req, res){
 
 		if( httpResponse.statusCode != 200 ){
 			cityListLogger.error("status code %s", httpResponse.statusCode);
-			res.send(httpResponse.statusCode);
+			res.sendStatus(httpResponse.statusCode);
 			return;
 		}
 
@@ -35,6 +35,6 @@ exports.list = function(req, res){
 		});
 	}).on('error', function(e) {
 		cityListLogger.error("got error: ", e);
-		res.send(500, e.message);
+		res.sendStatus(500, e.message);
 	});
 };

--- a/modules/forecast.js
+++ b/modules/forecast.js
@@ -13,7 +13,7 @@ exports.retrieve = function(req, res){
 
 		if( httpResponse.statusCode != 200 ){
 			forecastLogger.error("status code %s", httpResponse.statusCode);
-			res.send(httpResponse.statusCode);
+			res.sendStatus(httpResponse.statusCode);
 			return;
 		}
 


### PR DESCRIPTION
Fix deprecated express method

express deprecated res.send(status): Use res.sendStatus(status) instead at weather-node.js/modules/forecast.js:16:8